### PR TITLE
fix: configure tsconfig path alias for db

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -17,12 +17,22 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- add TypeScript path alias so Next.js can resolve `@/lib/db`

## Testing
- `npm -w web run build`


------
https://chatgpt.com/codex/tasks/task_e_689c236ca8748321a09e0b03b64b5678