### PR TITLE
feat: hash game build and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ npm -w web run dev
 # Run Phaser dev server
 npm -w game run dev
 
-# Build game and sync into web
+# Build Phaser game (hashed assets) and sync into web/public/game
 npm run build:game && npm run sync:game
 
 # Build Next.js for prod
 npm -w web run build && npm -w web run start
 ```
+
+The `sync:game` script copies the entire `game/dist` output, including hashed filenames, into `web/public/game`.
 
 ---
 

--- a/game/vite.config.ts
+++ b/game/vite.config.ts
@@ -2,5 +2,14 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   server: { port: 5173 },
-  build: { outDir: 'dist' }
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/[name].[hash].js',
+        chunkFileNames: 'assets/[name].[hash].js',
+        assetFileNames: 'assets/[name].[hash][extname]'
+      }
+    }
+  }
 });

--- a/scripts/sync-game.mjs
+++ b/scripts/sync-game.mjs
@@ -10,20 +10,5 @@ if (!fs.existsSync(gameDist)) {
   process.exit(1);
 }
 fs.rmSync(webPublicGame, { recursive: true, force: true });
-fs.mkdirSync(webPublicGame, { recursive: true });
-
-// copy recursively
-function copyDir(src, dest) {
-  for (const item of fs.readdirSync(src, { withFileTypes: true })) {
-    const s = path.join(src, item.name);
-    const d = path.join(dest, item.name);
-    if (item.isDirectory()) {
-      fs.mkdirSync(d, { recursive: true });
-      copyDir(s, d);
-    } else if (item.isFile()) {
-      fs.copyFileSync(s, d);
-    }
-  }
-}
-copyDir(gameDist, webPublicGame);
+fs.cpSync(gameDist, webPublicGame, { recursive: true });
 console.log('Copied game/dist -> web/public/game');


### PR DESCRIPTION
## Summary
- ensure Vite game build outputs hashed assets
- copy entire game/dist into Next.js public folder
- document build & sync workflow

## Testing
- `npm -w game run build`
- `node scripts/sync-game.mjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c2c388d748321b880473823625864