### PR TITLE
feat: validate API payloads and add tests

### DIFF
--- a/web/app/api/run/route.ts
+++ b/web/app/api/run/route.ts
@@ -1,26 +1,40 @@
 import { NextResponse } from 'next/server';
-import { sql } from '@/lib/db';
+import { z } from 'zod';
+import { sql } from '../../../lib/db';
 
-export async function POST(req: Request){
-  try{
+const RunSchema = z.object({
+  userId: z.string().uuid().nullable().optional(),
+  score: z.number().int(),
+  timeMs: z.number().int(),
+  difficulty: z.string(),
+  bosses: z.number().int(),
+  lettuce: z.number().int(),
+});
+
+export async function POST(req: Request) {
+  try {
     const body = await req.json();
-    const { userId = null, score = 0, timeMs = 0, difficulty = 'standard', bosses = 0, lettuce = 0 } = body ?? {};
+    const parsed = RunSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'invalid payload' }, { status: 400 });
+    }
+    const { userId = null, score, timeMs, difficulty, bosses, lettuce } = parsed.data;
 
     await sql`INSERT INTO runs (user_id, score, time_ms, difficulty, bosses_defeated, lettuce)
               VALUES (${userId}, ${score}, ${timeMs}, ${difficulty}, ${bosses}, ${lettuce})`;
 
     return NextResponse.json({ ok: true });
-  }catch(err: any){
+  } catch (err: any) {
     return NextResponse.json({ ok: false, error: err?.message ?? 'error' }, { status: 500 });
   }
 }
 
-export async function GET(){
-  try{
+export async function GET() {
+  try {
     const rows = await sql`SELECT id, score, time_ms, difficulty, bosses_defeated, lettuce, created_at
                            FROM runs ORDER BY score DESC, created_at DESC LIMIT 20`;
-    return NextResponse.json({ ok: true, rows });
-  }catch(err: any){
+    return NextResponse.json({ ok: true, data: rows });
+  } catch (err: any) {
     return NextResponse.json({ ok: false, error: err?.message ?? 'error' }, { status: 500 });
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -8,17 +8,21 @@
     "build": "next build",
     "start": "next start",
     "lint": "echo \"no lint configured\"",
-    "db:init": "node scripts/db-init.mjs"
+    "db:init": "node scripts/db-init.mjs",
+    "test": "tsx test/api-routes.test.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.8.0",
     "next": "^14.2.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.7.0"
   }
 }

--- a/web/test/api-routes.test.ts
+++ b/web/test/api-routes.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert';
+import { POST as runPost } from '../app/api/run/route.ts';
+import { GET as profileGet, POST as profilePost } from '../app/api/profile/route.ts';
+
+async function runTests() {
+  // POST /api/run invalid payload
+  {
+    const req = new Request('http://localhost/api/run', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ score: 'bad' })
+    });
+    const res = await runPost(req);
+    assert.strictEqual(res.status, 400);
+    const json = await res.json();
+    assert.strictEqual(json.ok, false);
+    assert.ok(json.error);
+    console.log('POST /api/run invalid payload: ok');
+  }
+
+  // GET /api/profile missing userId
+  {
+    const req = new Request('http://localhost/api/profile');
+    const res = await profileGet(req);
+    assert.strictEqual(res.status, 400);
+    const json = await res.json();
+    assert.strictEqual(json.ok, false);
+    assert.ok(json.error);
+    console.log('GET /api/profile requires userId: ok');
+  }
+
+  // POST /api/profile invalid payload
+  {
+    const req = new Request('http://localhost/api/profile', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle: 'abc' })
+    });
+    const res = await profilePost(req);
+    assert.strictEqual(res.status, 400);
+    const json = await res.json();
+    assert.strictEqual(json.ok, false);
+    assert.ok(json.error);
+    console.log('POST /api/profile invalid payload: ok');
+  }
+
+  console.log('All tests passed');
+}
+
+runTests().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- use Zod to validate /api/run and /api/profile requests
- normalize API responses to {ok,data?,error?}
- add basic tests for API route validation

## Testing
- `npm --prefix web test`


------
https://chatgpt.com/codex/tasks/task_e_689c31dce59c8321ba8a0b5b3ac01069