### PR TITLE
feat(game): set base path for Vite build

### DIFF
--- a/game/vite.config.ts
+++ b/game/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: './',
   server: { port: 5173 },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- set Vite base path to './' so built assets resolve correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm -w game run build`


------
https://chatgpt.com/codex/tasks/task_e_689c466d92c0832180ae7ec0dd18f71f