### PR TITLE
feat: add lane-aware collision checks

### DIFF
--- a/game/src/systems/collision.ts
+++ b/game/src/systems/collision.ts
@@ -1,0 +1,27 @@
+export function laneBand(target: { getData?: (key: string) => any }, band = 40): number {
+  const size = target?.getData?.('size');
+  switch (size) {
+    case 'S':
+      return band * 0.5; // smaller targets, tighter band
+    case 'L':
+      return band * 1.5; // larger targets, wider band
+    default:
+      return band;
+  }
+}
+
+export function laneOverlap(aY: number, bY: number, band = 40): boolean {
+  return Math.abs(aY - bY) < band;
+}
+
+export function projectileHitsEnemy(projectile: { y: number }, enemy: { y: number; getData?: (key: string) => any }): boolean {
+  return laneOverlap(projectile.y, enemy.y, laneBand(enemy));
+}
+
+export function enemyHitsPlayer(enemy: { y: number }, player: { y: number; getData?: (key: string) => any }): boolean {
+  return laneOverlap(enemy.y, player.y, laneBand(player));
+}
+
+export function pickupHitsPlayer(pickup: { y: number }, player: { y: number; getData?: (key: string) => any }): boolean {
+  return laneOverlap(pickup.y, player.y, laneBand(player));
+}


### PR DESCRIPTION
## Summary
- add `laneOverlap` helper with size-aware lane band calculations
- gate projectile, enemy, and pickup collisions by lane overlap

## Testing
- `npm -w game run build`
- `npm -w web test`


------
https://chatgpt.com/codex/tasks/task_e_689c4ca831688321b7b33fac64754719