### PR TITLE
feat: add boss base class and fsm

### DIFF
--- a/game/src/entities/boss/BaseBoss.ts
+++ b/game/src/entities/boss/BaseBoss.ts
@@ -1,0 +1,35 @@
+import Phaser from 'phaser';
+import { FSM } from '../../systems/fsm';
+
+export class BaseBoss extends Phaser.Physics.Arcade.Sprite {
+  hp: number;
+  states: FSM;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, texture: string, hp = 1) {
+    super(scene, x, y, texture);
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+    this.hp = hp;
+    this.states = new FSM();
+  }
+
+  preUpdate(t: number, dt: number) {
+    super.preUpdate(t, dt);
+    this.states.update(dt / 1000);
+  }
+
+  takeDamage(n: number) {
+    this.hp -= n;
+    if (this.hp <= 0) {
+      this.emit('onDefeated');
+    }
+  }
+
+  setState(name: string | number) {
+    const stateName = String(name);
+    console.log(`Boss state -> ${stateName}`);
+    this.states.setState(stateName);
+    this.emit('onPhaseStart', stateName);
+    return this;
+  }
+}

--- a/game/src/entities/boss/DummyBoss.ts
+++ b/game/src/entities/boss/DummyBoss.ts
@@ -1,0 +1,12 @@
+import Phaser from 'phaser';
+import { BaseBoss } from './BaseBoss';
+
+export class DummyBoss extends BaseBoss {
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y, 'boss', 20);
+    this.states
+      .addState('idle', {})
+      .addState('rage', {});
+    this.setState('idle');
+  }
+}

--- a/game/src/scenes/GameScene.ts
+++ b/game/src/scenes/GameScene.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import { DummyBoss } from '../entities/boss/DummyBoss';
 
 const LANE_TOP = 360;
 const LANE_BOTTOM = 520;
@@ -26,6 +27,8 @@ export class GameScene extends Phaser.Scene {
   private enemies!: Phaser.Physics.Arcade.Group;
   private bullets!: Phaser.Physics.Arcade.Group;
 
+  private boss!: DummyBoss;
+
   private hudText!: Phaser.GameObjects.Text;
 
   constructor(){ super('game'); }
@@ -44,6 +47,14 @@ export class GameScene extends Phaser.Scene {
     // groups
     this.enemies = this.physics.add.group();
     this.bullets = this.physics.add.group();
+
+    // dummy boss
+    this.boss = new DummyBoss(this, 1000, LANE_TOP);
+
+    this.time.addEvent({
+      delay: 2000,
+      callback: () => this.boss.setState('rage')
+    });
 
     // spawn a few enemies to start
     for(let i=0;i<20;i++) this.spawnEnemy(600 + i*180 + Phaser.Math.Between(-40,40));

--- a/game/src/systems/fsm.ts
+++ b/game/src/systems/fsm.ts
@@ -1,0 +1,36 @@
+export type State = {
+  enter?: () => void;
+  update?: (dt: number) => void;
+  exit?: () => void;
+};
+
+export class FSM {
+  private states: Record<string, State> = {};
+  private current?: State;
+  private currentName?: string;
+
+  addState(name: string, state: State): this {
+    this.states[name] = state;
+    return this;
+  }
+
+  setState(name: string) {
+    if (this.currentName === name) return;
+    if (this.current && this.current.exit) this.current.exit();
+    const state = this.states[name];
+    if (!state) throw new Error(`State ${name} not found`);
+    this.current = state;
+    this.currentName = name;
+    if (state.enter) state.enter();
+  }
+
+  update(dt: number) {
+    if (this.current && this.current.update) {
+      this.current.update(dt);
+    }
+  }
+
+  get state() {
+    return this.currentName;
+  }
+}


### PR DESCRIPTION
## Summary
- add simple FSM with enter/update/exit hooks
- implement BaseBoss with hp, state machine and damage handling
- spawn DummyBoss in game scene and log state switches

## Testing
- `npm -w game run build`


------
https://chatgpt.com/codex/tasks/task_e_689c4e8f051c8321862e5a0df9e71d44