### PR TITLE
feat: add controllable ally with command states

### DIFF
--- a/game/src/entities/ally/Grad.ts
+++ b/game/src/entities/ally/Grad.ts
@@ -1,0 +1,76 @@
+import Phaser from 'phaser';
+
+export type GradCommand = 'retreat' | 'hold' | 'advance';
+
+export class Grad extends Phaser.Physics.Arcade.Sprite {
+  hp: number;
+  maxHp: number;
+  regen: number; // hp per second
+  moveSpeed: number;
+  command: GradCommand;
+  leash: number;
+  holdOffset: number;
+  retreatOffset: number;
+
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y, 'joe');
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+
+    this.maxHp = 10;
+    this.hp = this.maxHp;
+    this.regen = 1;
+    this.moveSpeed = 200;
+    this.command = 'hold';
+    this.leash = 120;
+    this.holdOffset = 60;
+    this.retreatOffset = 120;
+
+    this.setData('size', 'M');
+  }
+
+  setCommand(cmd: GradCommand) {
+    this.command = cmd;
+  }
+
+  update(dt: number, player: Phaser.Physics.Arcade.Sprite) {
+    // regen
+    this.hp = Math.min(this.maxHp, this.hp + this.regen * dt);
+
+    // follow player's lane
+    this.y = player.y;
+
+    let targetX = this.x;
+    switch (this.command) {
+      case 'advance':
+        targetX = this.x + this.moveSpeed * dt;
+        break;
+      case 'hold':
+        targetX = player.x - this.holdOffset;
+        break;
+      case 'retreat':
+        targetX = player.x - this.retreatOffset;
+        break;
+    }
+
+    if (this.command === 'advance') {
+      this.x = targetX;
+    } else {
+      const dx = targetX - this.x;
+      const step = this.moveSpeed * dt;
+      if (Math.abs(dx) > step) {
+        this.x += step * Math.sign(dx);
+      } else {
+        this.x = targetX;
+      }
+
+      // leash: stay close to the player when not advancing
+      if (this.x > player.x + this.leash) {
+        this.x = player.x + this.leash;
+      }
+    }
+
+    this.setDepth(this.y);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Grad ally with hp, regen and command states
- wire GameScene to spawn Grad and handle retreat/hold/advance commands
- clamp ally ahead distance when not advancing

## Testing
- `npm -w game test` (fails: Missing script "test")
- `npm -w game run build`


------
https://chatgpt.com/codex/tasks/task_e_689c56f16334832182fd8ac265184b80