### PR TITLE
feat: add ally kill tracking and promotions

### DIFF
--- a/game/src/renderHelpers.ts
+++ b/game/src/renderHelpers.ts
@@ -20,7 +20,7 @@ export function createNameplate(scene: Phaser.Scene, text: string) {
   return nameplate;
 }
 
-const LEVEL_TITLES = ['', 'Rookie', 'Veteran', 'Elite', 'Legend'];
+const LEVEL_TITLES = ['', 'Rookie', 'Veteran', 'Elite', 'Legend', 'Mythic'];
 
 export function titleByLevel(level: number): string {
   return LEVEL_TITLES[level] ?? '';


### PR DESCRIPTION
## Summary
- track kills for each Grad and promote them at 3/8/18/35 kills
- scale Grad projectile damage, fire rate, and pierce with level
- let allies fire projectiles and increment their kill counts on enemy deaths

## Testing
- `npm -w game run build`

------
https://chatgpt.com/codex/tasks/task_e_689c6db33d3883219175cbb867da65b9